### PR TITLE
Feature/strict from to ranges

### DIFF
--- a/src/__tests__/blockchain.test.ts
+++ b/src/__tests__/blockchain.test.ts
@@ -168,4 +168,10 @@ describe('blockchain', function () {
         const ts = new Date(header.timestamp + 'Z').getTime();
         expect(Math.abs(ts / 1000 - now / 1000)).toBeLessThan(120);
     });
+
+    it('Cannot start later than head block', async function () {
+        const headBlock = await TEST_CLIENT.blockchain.getCurrentBlockNum();
+        const blockStream = await TEST_CLIENT.blockchain.getBlockNumbers({ from: headBlock + 1000 });
+        await expect(blockStream.next()).rejects;
+    });
 });

--- a/src/__tests__/blockchain.test.ts
+++ b/src/__tests__/blockchain.test.ts
@@ -174,4 +174,11 @@ describe('blockchain', function () {
         const blockStream = await TEST_CLIENT.blockchain.getBlockNumbers({ from: headBlock + 1000 });
         await expect(blockStream.next()).rejects;
     });
+
+    it('Reversed from-to should generate nothing', async function () {
+        const blockStream = await TEST_CLIENT.blockchain.getBlockNumbers({ from: 1000, to: 900 });
+        const firstBlock = await blockStream.next();
+        expect(firstBlock.done).toBeTruthy();
+        expect(firstBlock.value).toBeUndefined();
+    });
 });

--- a/src/modules/blockchain.ts
+++ b/src/modules/blockchain.ts
@@ -271,10 +271,10 @@ export class Blockchain {
         let seen = options.from !== undefined ? options.from : current;
         while (true) {
             while (current > seen) {
-                yield seen++;
                 if (options.to !== undefined && seen > options.to) {
                     return;
                 }
+                yield seen++;
             }
             await sleep(interval * 1000);
             current = await this.getCurrentBlockNum(options.mode);


### PR DESCRIPTION
Found a small bug where `from > to` still leading to one entry in my sequence of block numbers.