### PR TITLE
v1.0.26 - Feature/get account auths (QOL-573)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "splinterlands-dhive-sl",
-    "version": "1.0.25",
+    "version": "1.0.26",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "splinterlands-dhive-sl",
-            "version": "1.0.25",
+            "version": "1.0.26",
             "license": "BSD-3-Clause-No-Military-License",
             "dependencies": {
                 "bigi": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "splinterlands-dhive-sl",
-    "version": "1.0.25",
+    "version": "1.0.26",
     "description": "An interface to the Hive blockchain which supports multi-node redundancy for high availability systems. Fork of dhive.",
     "main": "dist/dhive-sl.js",
     "module": "dist/dhive-sl.esm.js",

--- a/src/__tests__/database.test.ts
+++ b/src/__tests__/database.test.ts
@@ -1,4 +1,4 @@
-import { Asset, PrivateKey, generatePassword, Transaction } from '..';
+import { Asset, PrivateKey, generatePassword, Transaction, AccountAuthsAccount } from '..';
 import { sortAsc } from '../utils';
 import { TEST_CLIENT } from './common';
 
@@ -9,8 +9,61 @@ describe('database api', function () {
     let serverConfig: { [key: string]: boolean | string | number };
 
     it('should getAccount', async () => {
-        const account = await TEST_CLIENT.database.getAccount('initminer', { logErrors: false });
-        expect(account?.name).toEqual('initminer');
+        const account = await TEST_CLIENT.database.getAccount('dhive-sl', { logErrors: false });
+        expect(account?.name).toEqual('dhive-sl');
+    });
+
+    it('should getAccountAuths', async () => {
+        const auths = await TEST_CLIENT.database.getAccountAuths('dhive-sl', 'posting');
+        expect(auths.keys.length === 3).toBeTruthy();
+        expect(auths.accounts.length === 4).toBeTruthy();
+        expect(auths.threshold).toEqual(2);
+
+        for (const keyAuth of auths.keys) {
+            if (keyAuth.key === 'STM6J2hTGcwU9xSrcb5mzyLPw3Wig8YCcvDrQZ8sMLSz3JN4BQWVj') {
+                expect(keyAuth.weight).toEqual(2);
+                expect(keyAuth.threshold_reached).toBeTruthy();
+            } else if (keyAuth.key === 'STM7Mn9hpcaTJoUNzpH8EQJXTC6sjUptEoTgdKwvjM4DCTN3xDWjE') {
+                expect(keyAuth.weight).toEqual(1);
+                expect(keyAuth.threshold_reached).toBeFalsy();
+            } else if (keyAuth.key === 'STM8buYSYDiZ5gwLsqUBsGyvXaiWWiuwcW8d8d1snfXHsH81KMW66') {
+                expect(keyAuth.weight).toEqual(1);
+                expect(keyAuth.threshold_reached).toBeFalsy();
+            }
+        }
+
+        for (const accountAuth of auths.accounts) {
+            if (accountAuth.key === 'STM6JeCCbawL6yptpuUstnEroaUVbc46EYYLgNkzgsTBGSydFz6qk') {
+                expect(accountAuth.weight).toEqual(2);
+                expect(accountAuth.account).toEqual('dhive-sl-2');
+                expect(accountAuth.account_weight).toEqual(2);
+                expect(accountAuth.account_threshold).toEqual(2);
+                expect(accountAuth.threshold_reached).toBeTruthy();
+            } else if (accountAuth.key === 'STM6oZs7MaFo9VC4NYUy3kdqkAG5cT8sKvUWNw3SmHdSmj6DSaTDB') {
+                expect(accountAuth.weight).toEqual(1);
+                expect(accountAuth.account).toEqual('dhive-sl-2');
+                expect(accountAuth.account_weight).toEqual(2);
+                expect(accountAuth.account_threshold).toEqual(2);
+                expect(accountAuth.threshold_reached).toBeFalsy();
+            } else if (accountAuth.key === 'STM72nZZHPZu34634TML6vbxoz4PwGpzCabYcQjbpFbCegiafT9FJ') {
+                expect(accountAuth.weight).toEqual(1);
+                expect(accountAuth.account).toEqual('dhive-sl-2');
+                expect(accountAuth.account_weight).toEqual(2);
+                expect(accountAuth.account_threshold).toEqual(2);
+                expect(accountAuth.threshold_reached).toBeFalsy();
+            } else if (accountAuth.key === 'STM6q23tKVxbVhcTWEBo39Gxb5JP4ipNsmpqBLEJuPwtv7srEAyjD') {
+                expect(accountAuth.weight).toEqual(1);
+                expect(accountAuth.account).toEqual('dhive-sl-3');
+                expect(accountAuth.account_weight).toEqual(1);
+                expect(accountAuth.account_threshold).toEqual(1);
+                expect(accountAuth.threshold_reached).toBeFalsy();
+            }
+        }
+
+        const activeAuths = await TEST_CLIENT.database.getAccountAuths('dhive-sl', 'active');
+        expect(activeAuths.keys.length === 1).toBeTruthy();
+        expect(activeAuths.accounts.length === 1).toBeTruthy();
+        expect(activeAuths.threshold).toEqual(1);
     });
 
     it('getDynamicGlobalProperties', async function () {

--- a/src/chain/asset.ts
+++ b/src/chain/asset.ts
@@ -192,7 +192,7 @@ export class RCAsset {
      * @param symbol Symbol to use when created from number. Will also be used to validate
      *               the asset, throws if the passed value has a different symbol than this.
      */
-    public static from(value: string | Asset | number, symbol?: AssetSymbolRC) {
+    public static from(value: string | Asset | number, symbol?: AssetSymbolRC): RCAsset {
         if (value instanceof RCAsset) {
             if (symbol && value.symbol !== symbol) {
                 throw new Error(`Invalid asset, expected symbol: ${symbol} got: ${value.symbol}`);

--- a/src/chain/transaction.ts
+++ b/src/chain/transaction.ts
@@ -43,7 +43,7 @@ export class Transaction {
      * How many milliseconds in the future to set the expiry time to when
      * broadcasting a transaction, defaults to 10 minutes.
      */
-    public static expireTime = 600 * 1000;
+    public static expireTime = 10 * 60 * 1000;
 
     public ref_block_num: TransactionParameters['ref_block_num'];
     public ref_block_prefix: TransactionParameters['ref_block_prefix'];

--- a/src/clientFetch.ts
+++ b/src/clientFetch.ts
@@ -207,7 +207,7 @@ export class ClientFetch {
             /**
              * Beacon nodes loading hasn't started yet and no nodes have been given as parameter
              */
-            if (!this.beacon.loadOnInitialize && (!this.nodes || this.nodes.filter((node) => !node.disabled).length <= 0)) {
+            if (!this.beacon.loadOnInitialize && (!this.nodes || this.nodes.length <= 0)) {
                 /**
                  * Load beacon nodes
                  */


### PR DESCRIPTION
Includes some smaller bug-fixed as well as `getAccountAuths`, which returns the key-authorities and account-authorities (incl. the respective keys). The function does not return more than one level, meaning the account-authorities of the account-authorities.